### PR TITLE
Allow partial updates to DeploymentConfig

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,10 +7,10 @@
 		"READEME.md"
 	],
 	"scripts": {
-		"build:dev": "npm generate:sdk-client && node ./scripts/build.js --dev",
-		"build:prod": "npm generate:sdk-client && node ./scripts/build.js",
+		"build:dev": "npm run generate:sdk-client && node ./scripts/build.js --dev",
+		"build:prod": "npm run generate:sdk-client && node ./scripts/build.js",
 		"generate:sdk-client": "openapi-generator-cli generate -i swagger.json -o sdk-client -g typescript-fetch",
-		"package": "npm build:prod && pkg dist/cli.js --targets node14-linux-x64,node14-macos-x64,node14-win-x64 --output dist/hathora-cloud",
+		"package": "npm run build:prod && pkg dist/cli.js --targets node14-linux-x64,node14-macos-x64,node14-win-x64 --output dist/hathora-cloud",
 		"typecheck": "tsc --noEmit"
 	},
 	"devDependencies": {

--- a/src/commands/apps/create.ts
+++ b/src/commands/apps/create.ts
@@ -28,7 +28,7 @@ export const appCreateCommand: CommandModule<
 					},
 				},
 			});
-			console.log(response);
+			console.log(JSON.stringify(response));
 		} catch (e) {
 			if (e instanceof ResponseError) {
 				ERROR_MESSAGES.RESPONSE_ERROR(

--- a/src/commands/apps/list.ts
+++ b/src/commands/apps/list.ts
@@ -32,7 +32,7 @@ export const listAppsCommand: CommandModule<
 		try {
 			let response = await client.getApps();
 			if (args.raw) {
-				console.log(response);
+				console.log(JSON.stringify(response));
 			} else {
 				console.table(response, args.fields.split(","));
 			}

--- a/src/commands/build/create.ts
+++ b/src/commands/build/create.ts
@@ -1,10 +1,50 @@
-import { CommandModule } from "yargs";
+import { ArgumentsCamelCase, CommandModule } from "yargs";
 import { ERROR_MESSAGES } from "../../util/errors";
-import { ResponseError } from "../../../sdk-client";
+import { Build, ResponseError } from "../../../sdk-client";
 import { stat } from "fs/promises";
 import { createReadStream } from "fs";
 import { createTar } from "../../util/createTar";
 import { getBuildApiClient } from "../../util/getClient";
+
+
+export const createBuild = async (args: ArgumentsCamelCase<{
+	appId: string;
+	file: string;
+	token: string;
+}>): Promise<number> => {
+	const client = getBuildApiClient(args.token);
+	try {
+		if (args.file && !(await stat(args.file)).isFile()) {
+			return ERROR_MESSAGES.FILE_NOT_FOUND(args.file);
+		}
+
+		const fileContents =
+			args.file === undefined
+				? await createTar()
+				: createReadStream(args.file);
+
+		const createResponse = await client.createBuild({
+			appId: args.appId,
+		});
+		const buildResponse = await client.runBuildRaw({
+			appId: args.appId,
+			buildId: createResponse.buildId,
+			file: fileContents, // readable stream works with the form-data package but the generated sdk wants a blob.
+		});
+		let body = buildResponse.raw.body!;
+		body["pipe"](process.stdout);
+		await buildResponse.value();
+		return createResponse.buildId;
+	} catch (e) {
+		if (e instanceof ResponseError) {
+			ERROR_MESSAGES.RESPONSE_ERROR(
+				e.response.status.toString(),
+				e.response.statusText
+			);
+		}
+		throw e;
+	}
+}
 
 export const createBuildCommand: CommandModule<
 	{},
@@ -29,36 +69,7 @@ export const createBuildCommand: CommandModule<
 		token: { type: "string", demandOption: true, hidden: true },
 	},
 	handler: async (args) => {
-		const client = getBuildApiClient(args.token);
-		try {
-			if (args.file && !(await stat(args.file)).isFile()) {
-				return ERROR_MESSAGES.FILE_NOT_FOUND(args.file);
-			}
-
-			const fileContents =
-				args.file === undefined
-					? await createTar()
-					: createReadStream(args.file);
-
-			const createResponse = await client.createBuild({
-				appId: args.appId,
-			});
-			const buildResponse = await client.runBuildRaw({
-				appId: args.appId,
-				buildId: createResponse.buildId,
-				file: fileContents, // readable stream works with the form-data package but the generated sdk wants a blob.
-			});
-			let body = buildResponse.raw.body!;
-			body["pipe"](process.stdout);
-			await buildResponse.value();
-		} catch (e) {
-			if (e instanceof ResponseError) {
-				ERROR_MESSAGES.RESPONSE_ERROR(
-					e.response.status.toString(),
-					e.response.statusText
-				);
-			}
-			throw e;
-		}
+		const buildId = await createBuild(args)
+		console.log(`Build created with id ${buildId}`);
 	},
 };

--- a/src/commands/build/list.ts
+++ b/src/commands/build/list.ts
@@ -40,7 +40,7 @@ export const listBuildsCommand: CommandModule<
 				appId: args.appId,
 			});
 			if (args.raw) {
-				console.log(response);
+				console.log(JSON.stringify(response));
 			} else {
 				console.table(response, args.fields.split(","));
 			}

--- a/src/commands/deploy.ts
+++ b/src/commands/deploy.ts
@@ -1,22 +1,21 @@
 import { CommandModule } from "yargs";
 import { ERROR_MESSAGES } from "../util/errors";
-import { getBuildApiClient, getDeploymentApiClient } from "../util/getClient";
 import { ResponseError } from "../../sdk-client";
-import { stat } from "fs/promises";
-import { createReadStream } from "fs";
-import { createTar } from "../util/createTar";
+import { createDeployment } from "./deployments/create";
+import { createBuild } from "./build/create";
 
 export const deployCommand: CommandModule<
 	{},
 	{
 		appId: string;
-		file: string;
-		roomsPerProcess: number;
-		planName: "tiny" | "small" | "medium" | "large";
-		transportType: "tcp" | "udp" | "tls";
-		containerPort: number;
-		env: string;
 		token: string;
+		file: string;
+		roomsPerProcess?: number;
+		planName?: "tiny" | "small" | "medium" | "large";
+		transportType?: "tcp" | "udp" | "tls";
+		containerPort?: number;
+		env?: string;
+		buildId?: number;
 	}
 > = {
 	command: "deploy",
@@ -33,72 +32,35 @@ export const deployCommand: CommandModule<
 		},
 		roomsPerProcess: {
 			type: "number",
-			demandOption: true,
 			describe: "number of rooms per process",
 		},
 		planName: {
 			type: "string",
-			demandOption: true,
 			choices: ["tiny", "small", "medium", "large"],
 			describe: "plan name",
 		},
 		transportType: {
 			type: "string",
-			demandOption: true,
 			choices: ["tcp", "udp", "tls"],
 			describe: "transport type",
 		},
 		containerPort: {
 			type: "number",
-			demandOption: true,
 			describe: "port the container listens to",
 		},
 		env: {
 			type: "string",
-			demandOption: true,
 			describe:
 				"JSON stringified version of env variables array (name and value)",
 		},
 		token: { type: "string", demandOption: true, hidden: true },
 	},
 	handler: async (args) => {
-		const deployClient = getDeploymentApiClient(args.token);
-		const buildClient = getBuildApiClient(args.token);
 		try {
-			const response = await buildClient.createBuild({
-				appId: args.appId,
-			});
-
-			if (args.file && !(await stat(args.file)).isFile()) {
-				return ERROR_MESSAGES.FILE_NOT_FOUND(args.file);
-			}
-
-			const fileContents =
-				args.file === undefined
-					? await createTar()
-					: createReadStream(args.file);
-			const buildResponse = await buildClient.runBuildRaw({
-				appId: args.appId,
-				buildId: response.buildId,
-				file: fileContents, // readable stream works with the form-data package but the generated sdk wants a blob.
-			});
-			let body = buildResponse.raw.body!;
-			body["pipe"](process.stdout);
-
-			await buildResponse.value();
-
+			const buildId = await createBuild(args);
+			args.buildId = buildId;
 			console.log("Creating deployment...");
-			const deployment = await deployClient.createDeployment({
-				appId: args.appId,
-				buildId: response.buildId,
-				deploymentConfig: {
-					roomsPerProcess: args.roomsPerProcess,
-					planName: args.planName,
-					transportType: args.transportType,
-					containerPort: args.containerPort,
-					env: JSON.parse(args.env),
-				},
-			});
+			const deployment = await createDeployment(args);
 			console.log(
 				"Deployment created! (deployment id: " +
 					deployment.deploymentId +

--- a/src/commands/deployments/create.ts
+++ b/src/commands/deployments/create.ts
@@ -105,6 +105,6 @@ export const createDeploymentCommand: CommandModule<
 	},
 	handler: async (args) => {
 		const deployment = await createDeployment(args);
-		console.log(deployment);
+		console.log(JSON.stringify(deployment));
 	}
 };

--- a/src/commands/deployments/create.ts
+++ b/src/commands/deployments/create.ts
@@ -1,19 +1,69 @@
-import { CommandModule } from "yargs";
+import { ArgumentsCamelCase, CommandModule } from "yargs";
 import { ERROR_MESSAGES } from "../../util/errors";
 import { getDeploymentApiClient } from "../../util/getClient";
-import { ResponseError } from "../../../sdk-client";
+import { Deployment, ResponseError } from "../../../sdk-client";
+
+export const createDeployment = async (args: ArgumentsCamelCase<{
+	appId: string;
+	token: string;
+	buildId?: number | undefined;
+	roomsPerProcess?: number | undefined;
+	planName?: "tiny" | "small" | "medium" | "large" | undefined;
+	transportType?: "tcp" | "udp" | "tls" | undefined;
+	containerPort?: number | undefined;
+	env?: string | undefined;
+}>): Promise<Deployment> => {
+	const client = getDeploymentApiClient(args.token);
+	try {
+		const deployments = await client.getDeployments({appId: args.appId});
+		const lastDeployment = deployments.at(0);
+
+		if (lastDeployment === undefined && (
+			args.buildId === undefined ||
+			args.roomsPerProcess === undefined ||
+			args.planName === undefined ||
+			args.transportType === undefined ||
+			args.containerPort === undefined
+		)) {
+			throw new Error("All args must be present for the initial deployment");
+		}
+
+		const deployment = await client.createDeployment({
+			appId: args.appId,
+			buildId: args.buildId ?? lastDeployment!.buildId,
+			deploymentConfig: {
+				roomsPerProcess: args.roomsPerProcess ?? lastDeployment!.roomsPerProcess,
+				planName: args.planName ?? lastDeployment!.planName,
+				transportType: args.transportType ?? lastDeployment!.transportType,
+				containerPort: args.containerPort ?? lastDeployment!.containerPort,
+				env: args.env !== undefined ? JSON.parse(args.env) : lastDeployment?.env ?? [],
+				additionalContainerPorts: lastDeployment?.additionalContainerPorts ?? [],
+			},
+		});
+		return deployment;
+	} catch (e) {
+		if (e instanceof ResponseError) {
+			ERROR_MESSAGES.RESPONSE_ERROR(
+				e.response.status.toString(),
+				e.response.statusText
+			);
+		}
+		throw e;
+	}
+}
+
 
 export const createDeploymentCommand: CommandModule<
 	{},
 	{
 		appId: string;
-		roomsPerProcess: number;
-		planName: "tiny" | "small" | "medium" | "large";
-		transportType: "tcp" | "udp" | "tls";
-		containerPort: number;
-		buildId: number;
-		env: string;
 		token: string;
+		buildId?: number;
+		roomsPerProcess?: number;
+		planName?: "tiny" | "small" | "medium" | "large";
+		transportType?: "tcp" | "udp" | "tls";
+		containerPort?: number;
+		env?: string;
 	}
 > = {
 	command: "create",
@@ -21,7 +71,6 @@ export const createDeploymentCommand: CommandModule<
 	builder: {
 		buildId: {
 			type: "number",
-			demandOption: true,
 			describe: "Id of the build",
 		},
 		appId: {
@@ -31,57 +80,31 @@ export const createDeploymentCommand: CommandModule<
 		},
 		roomsPerProcess: {
 			type: "number",
-			demandOption: true,
 			describe: "number of rooms per process",
 		},
 		planName: {
 			type: "string",
-			demandOption: true,
 			choices: ["tiny", "small", "medium", "large"],
 			describe: "plan name",
 		},
 		transportType: {
 			type: "string",
-			demandOption: true,
 			choices: ["tcp", "udp", "tls"],
 			describe: "transport type",
 		},
 		containerPort: {
 			type: "number",
-			demandOption: true,
 			describe: "port the container listens to",
 		},
 		env: {
 			type: "string",
-			demandOption: true,
 			describe:
 				"JSON stringified version of env variables array (name and value)",
 		},
 		token: { type: "string", demandOption: true, hidden: true },
 	},
 	handler: async (args) => {
-		const client = getDeploymentApiClient(args.token);
-		try {
-			const deployment = await client.createDeployment({
-				appId: args.appId,
-				buildId: args.buildId,
-				deploymentConfig: {
-					roomsPerProcess: args.roomsPerProcess,
-					planName: args.planName,
-					transportType: args.transportType,
-					containerPort: args.containerPort,
-					env: JSON.parse(args.env),
-				},
-			});
-			console.log(deployment);
-		} catch (e) {
-			if (e instanceof ResponseError) {
-				ERROR_MESSAGES.RESPONSE_ERROR(
-					e.response.status.toString(),
-					e.response.statusText
-				);
-			}
-			throw e;
-		}
-	},
+		const deployment = await createDeployment(args);
+		console.log(deployment);
+	}
 };

--- a/src/commands/deployments/list.ts
+++ b/src/commands/deployments/list.ts
@@ -40,7 +40,7 @@ export const listDeploymentsCommand: CommandModule<
 				appId: args.appId,
 			});
 			if (args.raw) {
-				console.log(response);
+				console.log(JSON.stringify(response));
 			} else {
 				console.table(response, args.fields.split(","));
 			}

--- a/src/commands/processes/list.ts
+++ b/src/commands/processes/list.ts
@@ -60,7 +60,7 @@ export const listProcessesCommand: CommandModule<
 				region: args.region,
 			});
 			if (args.raw) {
-				console.log(response);
+				console.log(JSON.stringify(response));
 			} else {
 				console.table(response, args.fields.split(","));
 			}

--- a/src/commands/room/connect.ts
+++ b/src/commands/room/connect.ts
@@ -29,7 +29,7 @@ export const roomConnectionInfoCommand: CommandModule<
 				appId: args.appId,
 				roomId: args.roomId,
 			});
-			console.log(connectionInfo);
+			console.log(JSON.stringify(connectionInfo));
 		} catch (e) {
 			if (e instanceof ResponseError) {
 				ERROR_MESSAGES.RESPONSE_ERROR(

--- a/src/commands/room/create.ts
+++ b/src/commands/room/create.ts
@@ -30,7 +30,7 @@ export const roomCreateCommand: CommandModule<
 				appId: args.appId,
 				createRoomRequest: { region: args.region },
 			});
-			console.log(room);
+			console.log(JSON.stringify(room));
 		} catch (e) {
 			if (e instanceof ResponseError) {
 				ERROR_MESSAGES.RESPONSE_ERROR(


### PR DESCRIPTION
Except on first deployment creation, make all other fields optional. If any fields don't exist, fetch the latest deployment and fill in the existing values.