### PR TITLE
Show `token` in CLI help messages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
 			"version": "1.9.0",
 			"license": "MIT",
 			"dependencies": {
-				"@types/node-fetch": "2",
 				"axios": "^1.3.3",
 				"chalk": "^4",
 				"commander": "^10.0.0",
@@ -21,7 +20,7 @@
 				"prompts": "^2.4.2",
 				"suppress-warnings": "^1.0.2",
 				"tar": "^6.1.13",
-				"yargs": "^17.6.2"
+				"yargs": "^17.7.2"
 			},
 			"bin": {
 				"hathora-cloud": "dist/cli.js"
@@ -31,9 +30,10 @@
 				"@types/axios": "^0.14.0",
 				"@types/fs-extra": "^11.0.1",
 				"@types/node": "^18.13.0",
+				"@types/node-fetch": "2",
 				"@types/prompts": "^2.4.2",
 				"@types/tar": "^6.1.4",
-				"@types/yargs": "^17.0.22",
+				"@types/yargs": "^17.0.24",
 				"esbuild": "^0.17.6",
 				"esbuild-plugin-node-externals": "^1.0.1",
 				"pkg": "^5.8.0",
@@ -791,12 +791,14 @@
 		"node_modules/@types/node": {
 			"version": "18.13.0",
 			"resolved": "https://registry.npmjs.org/@types/node/-/node-18.13.0.tgz",
-			"integrity": "sha512-gC3TazRzGoOnoKAhUx+Q0t8S9Tzs74z7m0ipwGpSqQrleP14hKxP4/JUeEQcD3W1/aIpnWl8pHowI7WokuZpXg=="
+			"integrity": "sha512-gC3TazRzGoOnoKAhUx+Q0t8S9Tzs74z7m0ipwGpSqQrleP14hKxP4/JUeEQcD3W1/aIpnWl8pHowI7WokuZpXg==",
+			"dev": true
 		},
 		"node_modules/@types/node-fetch": {
 			"version": "2.6.2",
 			"resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.2.tgz",
 			"integrity": "sha512-DHqhlq5jeESLy19TYhLakJ07kNumXWjcDdxXsLUMJZ6ue8VZJj4kLPQVE/2mdHh3xZziNF1xppu5lwmS53HR+A==",
+			"dev": true,
 			"dependencies": {
 				"@types/node": "*",
 				"form-data": "^3.0.0"
@@ -806,6 +808,7 @@
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.1.tgz",
 			"integrity": "sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==",
+			"dev": true,
 			"dependencies": {
 				"asynckit": "^0.4.0",
 				"combined-stream": "^1.0.8",
@@ -836,9 +839,9 @@
 			}
 		},
 		"node_modules/@types/yargs": {
-			"version": "17.0.22",
-			"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.22.tgz",
-			"integrity": "sha512-pet5WJ9U8yPVRhkwuEIp5ktAeAqRZOq4UdAyWLWzxbtpyXnzbtLdKiXAjJzi/KLmPGS9wk86lUFWZFN6sISo4g==",
+			"version": "17.0.24",
+			"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.24.tgz",
+			"integrity": "sha512-6i0aC7jV6QzQB8ne1joVZ0eSFIstHsCrobmOtghM11yGlH0j43FKL2UhWdELkyps0zuf7qVTUVCCR+tgSlyLLw==",
 			"dev": true,
 			"dependencies": {
 				"@types/yargs-parser": "*"
@@ -3635,9 +3638,9 @@
 			"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
 		},
 		"node_modules/yargs": {
-			"version": "17.6.2",
-			"resolved": "https://registry.npmjs.org/yargs/-/yargs-17.6.2.tgz",
-			"integrity": "sha512-1/9UrdHjDZc0eOU0HxOHoS78C69UD3JRMvzlJ7S79S2nTaWRA/whGCTV8o9e/N/1Va9YIV7Q4sOxD8VV4pCWOw==",
+			"version": "17.7.2",
+			"resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+			"integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
 			"dependencies": {
 				"cliui": "^8.0.1",
 				"escalade": "^3.1.1",
@@ -4126,12 +4129,14 @@
 		"@types/node": {
 			"version": "18.13.0",
 			"resolved": "https://registry.npmjs.org/@types/node/-/node-18.13.0.tgz",
-			"integrity": "sha512-gC3TazRzGoOnoKAhUx+Q0t8S9Tzs74z7m0ipwGpSqQrleP14hKxP4/JUeEQcD3W1/aIpnWl8pHowI7WokuZpXg=="
+			"integrity": "sha512-gC3TazRzGoOnoKAhUx+Q0t8S9Tzs74z7m0ipwGpSqQrleP14hKxP4/JUeEQcD3W1/aIpnWl8pHowI7WokuZpXg==",
+			"dev": true
 		},
 		"@types/node-fetch": {
 			"version": "2.6.2",
 			"resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.2.tgz",
 			"integrity": "sha512-DHqhlq5jeESLy19TYhLakJ07kNumXWjcDdxXsLUMJZ6ue8VZJj4kLPQVE/2mdHh3xZziNF1xppu5lwmS53HR+A==",
+			"dev": true,
 			"requires": {
 				"@types/node": "*",
 				"form-data": "^3.0.0"
@@ -4141,6 +4146,7 @@
 					"version": "3.0.1",
 					"resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.1.tgz",
 					"integrity": "sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==",
+					"dev": true,
 					"requires": {
 						"asynckit": "^0.4.0",
 						"combined-stream": "^1.0.8",
@@ -4170,9 +4176,9 @@
 			}
 		},
 		"@types/yargs": {
-			"version": "17.0.22",
-			"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.22.tgz",
-			"integrity": "sha512-pet5WJ9U8yPVRhkwuEIp5ktAeAqRZOq4UdAyWLWzxbtpyXnzbtLdKiXAjJzi/KLmPGS9wk86lUFWZFN6sISo4g==",
+			"version": "17.0.24",
+			"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.24.tgz",
+			"integrity": "sha512-6i0aC7jV6QzQB8ne1joVZ0eSFIstHsCrobmOtghM11yGlH0j43FKL2UhWdELkyps0zuf7qVTUVCCR+tgSlyLLw==",
 			"dev": true,
 			"requires": {
 				"@types/yargs-parser": "*"
@@ -6226,9 +6232,9 @@
 			"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
 		},
 		"yargs": {
-			"version": "17.6.2",
-			"resolved": "https://registry.npmjs.org/yargs/-/yargs-17.6.2.tgz",
-			"integrity": "sha512-1/9UrdHjDZc0eOU0HxOHoS78C69UD3JRMvzlJ7S79S2nTaWRA/whGCTV8o9e/N/1Va9YIV7Q4sOxD8VV4pCWOw==",
+			"version": "17.7.2",
+			"resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+			"integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
 			"requires": {
 				"cliui": "^8.0.1",
 				"escalade": "^3.1.1",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
 		"@types/node-fetch": "2",
 		"@types/prompts": "^2.4.2",
 		"@types/tar": "^6.1.4",
-		"@types/yargs": "^17.0.22",
+		"@types/yargs": "^17.0.24",
 		"esbuild": "^0.17.6",
 		"esbuild-plugin-node-externals": "^1.0.1",
 		"pkg": "^5.8.0",
@@ -40,7 +40,7 @@
 		"prompts": "^2.4.2",
 		"suppress-warnings": "^1.0.2",
 		"tar": "^6.1.13",
-		"yargs": "^17.6.2"
+		"yargs": "^17.7.2"
 	},
 	"bin": {
 		"hathora-cloud": "dist/cli.js"

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -50,5 +50,6 @@ yargs(hideBin(process.argv))
 	.command(deploymentsCommand)
 	.command(buildCommand)
 	.command(roomCommand)
+	.wrap(yargs.terminalWidth())
 	.help()
 	.parse();

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -34,8 +34,11 @@ const tokenMiddleware: MiddlewareFunction = (argv) => {
 	argv.token = readFileSync(tokenFile).toString();
 };
 
-yargs(hideBin(process.argv))
-	.version(version)
+// Needed to get the correct terminal width
+// https://github.com/yargs/yargs/blob/main/docs/typescript.md
+const yargsInstance = yargs(hideBin(process.argv))
+
+yargsInstance.version(version)
 	.scriptName("hathora-cloud")
 	.middleware(tokenMiddleware, true)
 	.demandCommand(1, "Please specify a command")
@@ -50,6 +53,6 @@ yargs(hideBin(process.argv))
 	.command(deploymentsCommand)
 	.command(buildCommand)
 	.command(roomCommand)
-	.wrap(yargs.terminalWidth())
+	.wrap(yargsInstance.terminalWidth())
 	.help()
 	.parse();

--- a/src/commands/apps/create.ts
+++ b/src/commands/apps/create.ts
@@ -18,7 +18,7 @@ export const appCreateCommand: CommandModule<
 		token: {
 			type: "string",
 			demandOption: true,
-			describe: "Hathora developer token (required if no config file is present)",
+			describe: "Hathora developer token (required if not present in the config file)",
 		},
 
 	},

--- a/src/commands/apps/create.ts
+++ b/src/commands/apps/create.ts
@@ -15,7 +15,7 @@ export const appCreateCommand: CommandModule<
 			demandOption: true,
 			describe: "Name of the app",
 		},
-		token: { type: "string", demandOption: true, hidden: true },
+		token: { type: "string", demandOption: true, hidden: false },
 	},
 	handler: async (args) => {
 		const client = getAppApiClient(args.token);

--- a/src/commands/apps/create.ts
+++ b/src/commands/apps/create.ts
@@ -15,7 +15,12 @@ export const appCreateCommand: CommandModule<
 			demandOption: true,
 			describe: "Name of the app",
 		},
-		token: { type: "string", demandOption: true, hidden: false },
+		token: {
+			type: "string",
+			demandOption: true,
+			describe: "Hathora developer token (required if no config file is present)",
+		},
+
 	},
 	handler: async (args) => {
 		const client = getAppApiClient(args.token);

--- a/src/commands/apps/create.ts
+++ b/src/commands/apps/create.ts
@@ -18,7 +18,7 @@ export const appCreateCommand: CommandModule<
 		token: {
 			type: "string",
 			demandOption: true,
-			describe: "Hathora developer token (required if not present in the config file)",
+			describe: "Hathora developer token (required only for CI environments)",
 		},
 
 	},

--- a/src/commands/apps/delete.ts
+++ b/src/commands/apps/delete.ts
@@ -15,7 +15,7 @@ export const appDeleteCommand: CommandModule<
 			demandOption: true,
 			describe: "Name of the app",
 		},
-		token: { type: "string", demandOption: true, hidden: true },
+		token: { type: "string", demandOption: true, hidden: false },
 	},
 	handler: async (args) => {
 		const client = getAppApiClient(args.token);

--- a/src/commands/apps/delete.ts
+++ b/src/commands/apps/delete.ts
@@ -18,7 +18,7 @@ export const appDeleteCommand: CommandModule<
 		token: {
 			type: "string",
 			demandOption: true,
-			describe: "Hathora developer token (required if no config file is present)",
+			describe: "Hathora developer token (required if not present in the config file)",
 		},
 
 	},

--- a/src/commands/apps/delete.ts
+++ b/src/commands/apps/delete.ts
@@ -18,7 +18,7 @@ export const appDeleteCommand: CommandModule<
 		token: {
 			type: "string",
 			demandOption: true,
-			describe: "Hathora developer token (required if not present in the config file)",
+			describe: "Hathora developer token (required only for CI environments)",
 		},
 
 	},

--- a/src/commands/apps/delete.ts
+++ b/src/commands/apps/delete.ts
@@ -15,7 +15,12 @@ export const appDeleteCommand: CommandModule<
 			demandOption: true,
 			describe: "Name of the app",
 		},
-		token: { type: "string", demandOption: true, hidden: false },
+		token: {
+			type: "string",
+			demandOption: true,
+			describe: "Hathora developer token (required if no config file is present)",
+		},
+
 	},
 	handler: async (args) => {
 		const client = getAppApiClient(args.token);

--- a/src/commands/apps/list.ts
+++ b/src/commands/apps/list.ts
@@ -25,7 +25,7 @@ export const listAppsCommand: CommandModule<
 			describe: "Show only the specified fields (comma separated)",
 			default: "appName,appId,createdAt",
 		},
-		token: { type: "string", demandOption: true, hidden: true },
+		token: { type: "string", demandOption: true, hidden: false },
 	},
 	handler: async (args) => {
 		const client = getAppApiClient(args.token);

--- a/src/commands/apps/list.ts
+++ b/src/commands/apps/list.ts
@@ -25,7 +25,12 @@ export const listAppsCommand: CommandModule<
 			describe: "Show only the specified fields (comma separated)",
 			default: "appName,appId,createdAt",
 		},
-		token: { type: "string", demandOption: true, hidden: false },
+		token: {
+			type: "string",
+			demandOption: true,
+			describe: "Hathora developer token (required if no config file is present)",
+		},
+
 	},
 	handler: async (args) => {
 		const client = getAppApiClient(args.token);

--- a/src/commands/apps/list.ts
+++ b/src/commands/apps/list.ts
@@ -28,7 +28,7 @@ export const listAppsCommand: CommandModule<
 		token: {
 			type: "string",
 			demandOption: true,
-			describe: "Hathora developer token (required if not present in the config file)",
+			describe: "Hathora developer token (required only for CI environments)",
 		},
 
 	},

--- a/src/commands/apps/list.ts
+++ b/src/commands/apps/list.ts
@@ -28,7 +28,7 @@ export const listAppsCommand: CommandModule<
 		token: {
 			type: "string",
 			demandOption: true,
-			describe: "Hathora developer token (required if no config file is present)",
+			describe: "Hathora developer token (required if not present in the config file)",
 		},
 
 	},

--- a/src/commands/build/create.ts
+++ b/src/commands/build/create.ts
@@ -66,7 +66,7 @@ export const createBuildCommand: CommandModule<
 			type: "string",
 			describe: "path to the tgz archive to deploy",
 		},
-		token: { type: "string", demandOption: true, hidden: true },
+		token: { type: "string", demandOption: true, hidden: false },
 	},
 	handler: async (args) => {
 		const buildId = await createBuild(args);

--- a/src/commands/build/create.ts
+++ b/src/commands/build/create.ts
@@ -69,7 +69,7 @@ export const createBuildCommand: CommandModule<
 		token: {
 			type: "string",
 			demandOption: true,
-			describe: "Hathora developer token (required if no config file is present)",
+			describe: "Hathora developer token (required if not present in the config file)",
 		},
 
 	},

--- a/src/commands/build/create.ts
+++ b/src/commands/build/create.ts
@@ -69,7 +69,7 @@ export const createBuildCommand: CommandModule<
 		token: {
 			type: "string",
 			demandOption: true,
-			describe: "Hathora developer token (required if not present in the config file)",
+			describe: "Hathora developer token (required only for CI environments)",
 		},
 
 	},

--- a/src/commands/build/create.ts
+++ b/src/commands/build/create.ts
@@ -66,7 +66,12 @@ export const createBuildCommand: CommandModule<
 			type: "string",
 			describe: "path to the tgz archive to deploy",
 		},
-		token: { type: "string", demandOption: true, hidden: false },
+		token: {
+			type: "string",
+			demandOption: true,
+			describe: "Hathora developer token (required if no config file is present)",
+		},
+
 	},
 	handler: async (args) => {
 		const buildId = await createBuild(args);

--- a/src/commands/build/delete.ts
+++ b/src/commands/build/delete.ts
@@ -23,7 +23,7 @@ export const buildDeleteCommand: CommandModule<
 		token: {
 			type: "string",
 			demandOption: true,
-			describe: "Hathora developer token (required if no config file is present)",
+			describe: "Hathora developer token (required if not present in the config file)",
 		},
 
 	},

--- a/src/commands/build/delete.ts
+++ b/src/commands/build/delete.ts
@@ -23,7 +23,7 @@ export const buildDeleteCommand: CommandModule<
 		token: {
 			type: "string",
 			demandOption: true,
-			describe: "Hathora developer token (required if not present in the config file)",
+			describe: "Hathora developer token (required only for CI environments)",
 		},
 
 	},

--- a/src/commands/build/delete.ts
+++ b/src/commands/build/delete.ts
@@ -20,7 +20,7 @@ export const buildDeleteCommand: CommandModule<
 			demandOption: true,
 			describe: "Build ID",
 		},
-		token: { type: "string", demandOption: true, hidden: true },
+		token: { type: "string", demandOption: true, hidden: false },
 	},
 	handler: async (args) => {
 		const client = getBuildApiClient(args.token);

--- a/src/commands/build/delete.ts
+++ b/src/commands/build/delete.ts
@@ -20,7 +20,12 @@ export const buildDeleteCommand: CommandModule<
 			demandOption: true,
 			describe: "Build ID",
 		},
-		token: { type: "string", demandOption: true, hidden: false },
+		token: {
+			type: "string",
+			demandOption: true,
+			describe: "Hathora developer token (required if no config file is present)",
+		},
+
 	},
 	handler: async (args) => {
 		const client = getBuildApiClient(args.token);

--- a/src/commands/build/list.ts
+++ b/src/commands/build/list.ts
@@ -34,7 +34,7 @@ export const listBuildsCommand: CommandModule<
 		token: {
 			type: "string",
 			demandOption: true,
-			describe: "Hathora developer token (required if no config file is present)",
+			describe: "Hathora developer token (required if not present in the config file)",
 		},
 
 	},

--- a/src/commands/build/list.ts
+++ b/src/commands/build/list.ts
@@ -31,7 +31,7 @@ export const listBuildsCommand: CommandModule<
 			describe: "Show only the specified fields (comma separated)",
 			default: "buildId,createdAt,createdBy,status",
 		},
-		token: { type: "string", demandOption: true, hidden: true },
+		token: { type: "string", demandOption: true, hidden: false },
 	},
 	handler: async (args) => {
 		const client = getBuildApiClient(args.token);

--- a/src/commands/build/list.ts
+++ b/src/commands/build/list.ts
@@ -34,7 +34,7 @@ export const listBuildsCommand: CommandModule<
 		token: {
 			type: "string",
 			demandOption: true,
-			describe: "Hathora developer token (required if not present in the config file)",
+			describe: "Hathora developer token (required only for CI environments)",
 		},
 
 	},

--- a/src/commands/build/list.ts
+++ b/src/commands/build/list.ts
@@ -31,7 +31,12 @@ export const listBuildsCommand: CommandModule<
 			describe: "Show only the specified fields (comma separated)",
 			default: "buildId,createdAt,createdBy,status",
 		},
-		token: { type: "string", demandOption: true, hidden: false },
+		token: {
+			type: "string",
+			demandOption: true,
+			describe: "Hathora developer token (required if no config file is present)",
+		},
+
 	},
 	handler: async (args) => {
 		const client = getBuildApiClient(args.token);

--- a/src/commands/deploy.ts
+++ b/src/commands/deploy.ts
@@ -56,7 +56,7 @@ export const deployCommand: CommandModule<
 		token: {
 			type: "string",
 			demandOption: true,
-			describe: "Hathora developer token (required if no config file is present)",
+			describe: "Hathora developer token (required if not present in the config file)",
 		},
 	},
 	handler: async (args) => {

--- a/src/commands/deploy.ts
+++ b/src/commands/deploy.ts
@@ -56,7 +56,7 @@ export const deployCommand: CommandModule<
 		token: {
 			type: "string",
 			demandOption: true,
-			describe: "Hathora developer token (required if not present in the config file)",
+			describe: "Hathora developer token (required only for CI environments)",
 		},
 	},
 	handler: async (args) => {

--- a/src/commands/deploy.ts
+++ b/src/commands/deploy.ts
@@ -53,7 +53,7 @@ export const deployCommand: CommandModule<
 			describe:
 				"JSON stringified version of env variables array (name and value)",
 		},
-		token: { type: "string", demandOption: true, hidden: true },
+		token: { type: "string", demandOption: true, hidden: false },
 	},
 	handler: async (args) => {
 		try {

--- a/src/commands/deploy.ts
+++ b/src/commands/deploy.ts
@@ -53,7 +53,11 @@ export const deployCommand: CommandModule<
 			describe:
 				"JSON stringified version of env variables array (name and value)",
 		},
-		token: { type: "string", demandOption: true, hidden: false },
+		token: {
+			type: "string",
+			demandOption: true,
+			describe: "Hathora developer token (required if no config file is present)",
+		},
 	},
 	handler: async (args) => {
 		try {
@@ -63,10 +67,10 @@ export const deployCommand: CommandModule<
 			const deployment = await createDeployment(args);
 			console.log(
 				"Deployment created! (deployment id: " +
-					deployment.deploymentId +
-					",build id: " +
-					deployment.buildId +
-					")"
+				deployment.deploymentId +
+				",build id: " +
+				deployment.buildId +
+				")"
 			);
 			// console.log(deployment);
 

--- a/src/commands/deployments/create.ts
+++ b/src/commands/deployments/create.ts
@@ -109,7 +109,7 @@ export const createDeploymentCommand: CommandModule<
 			describe:
 				"JSON stringified version of env variables array (name and value)",
 		},
-		token: { type: "string", demandOption: true, hidden: true },
+		token: { type: "string", demandOption: true, hidden: false },
 	},
 	handler: async (args) => {
 		const deployment = await createDeployment(args);

--- a/src/commands/deployments/create.ts
+++ b/src/commands/deployments/create.ts
@@ -112,7 +112,7 @@ export const createDeploymentCommand: CommandModule<
 		token: {
 			type: "string",
 			demandOption: true,
-			describe: "Hathora developer token (required if not present in the config file)",
+			describe: "Hathora developer token (required only for CI environments)",
 		},
 
 	},

--- a/src/commands/deployments/create.ts
+++ b/src/commands/deployments/create.ts
@@ -112,7 +112,7 @@ export const createDeploymentCommand: CommandModule<
 		token: {
 			type: "string",
 			demandOption: true,
-			describe: "Hathora developer token (required if no config file is present)",
+			describe: "Hathora developer token (required if not present in the config file)",
 		},
 
 	},

--- a/src/commands/deployments/create.ts
+++ b/src/commands/deployments/create.ts
@@ -109,7 +109,12 @@ export const createDeploymentCommand: CommandModule<
 			describe:
 				"JSON stringified version of env variables array (name and value)",
 		},
-		token: { type: "string", demandOption: true, hidden: false },
+		token: {
+			type: "string",
+			demandOption: true,
+			describe: "Hathora developer token (required if no config file is present)",
+		},
+
 	},
 	handler: async (args) => {
 		const deployment = await createDeployment(args);

--- a/src/commands/deployments/list.ts
+++ b/src/commands/deployments/list.ts
@@ -34,7 +34,7 @@ export const listDeploymentsCommand: CommandModule<
 		token: {
 			type: "string",
 			demandOption: true,
-			describe: "Hathora developer token (required if no config file is present)",
+			describe: "Hathora developer token (required if not present in the config file)",
 		},
 
 	},

--- a/src/commands/deployments/list.ts
+++ b/src/commands/deployments/list.ts
@@ -34,7 +34,7 @@ export const listDeploymentsCommand: CommandModule<
 		token: {
 			type: "string",
 			demandOption: true,
-			describe: "Hathora developer token (required if not present in the config file)",
+			describe: "Hathora developer token (required only for CI environments)",
 		},
 
 	},

--- a/src/commands/deployments/list.ts
+++ b/src/commands/deployments/list.ts
@@ -31,7 +31,12 @@ export const listDeploymentsCommand: CommandModule<
 			describe: "Show only the specified fields (comma separated)",
 			default: "deploymentId,createdAt,createdBy,buildId",
 		},
-		token: { type: "string", demandOption: true, hidden: false },
+		token: {
+			type: "string",
+			demandOption: true,
+			describe: "Hathora developer token (required if no config file is present)",
+		},
+
 	},
 	handler: async (args) => {
 		const client = getDeploymentApiClient(args.token);

--- a/src/commands/deployments/list.ts
+++ b/src/commands/deployments/list.ts
@@ -31,7 +31,7 @@ export const listDeploymentsCommand: CommandModule<
 			describe: "Show only the specified fields (comma separated)",
 			default: "deploymentId,createdAt,createdBy,buildId",
 		},
-		token: { type: "string", demandOption: true, hidden: true },
+		token: { type: "string", demandOption: true, hidden: false },
 	},
 	handler: async (args) => {
 		const client = getDeploymentApiClient(args.token);

--- a/src/commands/log.ts
+++ b/src/commands/log.ts
@@ -58,7 +58,7 @@ export const logAllCommand: CommandModule<
 		token: {
 			type: "string",
 			demandOption: true,
-			describe: "Hathora developer token (required if no config file is present)",
+			describe: "Hathora developer token (required if not present in the config file)",
 		},
 
 	},

--- a/src/commands/log.ts
+++ b/src/commands/log.ts
@@ -55,7 +55,12 @@ export const logAllCommand: CommandModule<
 			demandOption: false,
 			describe: "Id of the deployment (exclusive with processId)",
 		},
-		token: { type: "string", demandOption: true, hidden: false },
+		token: {
+			type: "string",
+			demandOption: true,
+			describe: "Hathora developer token (required if no config file is present)",
+		},
+
 	},
 	handler: async (args) => {
 		const client = getLogApiClient(args.token);

--- a/src/commands/log.ts
+++ b/src/commands/log.ts
@@ -55,7 +55,7 @@ export const logAllCommand: CommandModule<
 			demandOption: false,
 			describe: "Id of the deployment (exclusive with processId)",
 		},
-		token: { type: "string", demandOption: true, hidden: true },
+		token: { type: "string", demandOption: true, hidden: false },
 	},
 	handler: async (args) => {
 		const client = getLogApiClient(args.token);

--- a/src/commands/log.ts
+++ b/src/commands/log.ts
@@ -58,7 +58,7 @@ export const logAllCommand: CommandModule<
 		token: {
 			type: "string",
 			demandOption: true,
-			describe: "Hathora developer token (required if not present in the config file)",
+			describe: "Hathora developer token (required only for CI environments)",
 		},
 
 	},

--- a/src/commands/processes/list.ts
+++ b/src/commands/processes/list.ts
@@ -46,7 +46,7 @@ export const listProcessesCommand: CommandModule<
 			describe: "Show only the specified fields (comma separated)",
 			default: "processId,deploymentId,region,activeConnections",
 		},
-		token: { type: "string", demandOption: true, hidden: true },
+		token: { type: "string", demandOption: true, hidden: false },
 	},
 	handler: async (args) => {
 		const client = getProcessesApiClient(args.token);

--- a/src/commands/processes/list.ts
+++ b/src/commands/processes/list.ts
@@ -49,7 +49,7 @@ export const listProcessesCommand: CommandModule<
 		token: {
 			type: "string",
 			demandOption: true,
-			describe: "Hathora developer token (required if not present in the config file)",
+			describe: "Hathora developer token (required only for CI environments)",
 		},
 
 	},

--- a/src/commands/processes/list.ts
+++ b/src/commands/processes/list.ts
@@ -49,7 +49,7 @@ export const listProcessesCommand: CommandModule<
 		token: {
 			type: "string",
 			demandOption: true,
-			describe: "Hathora developer token (required if no config file is present)",
+			describe: "Hathora developer token (required if not present in the config file)",
 		},
 
 	},

--- a/src/commands/processes/list.ts
+++ b/src/commands/processes/list.ts
@@ -46,7 +46,12 @@ export const listProcessesCommand: CommandModule<
 			describe: "Show only the specified fields (comma separated)",
 			default: "processId,deploymentId,region,activeConnections",
 		},
-		token: { type: "string", demandOption: true, hidden: false },
+		token: {
+			type: "string",
+			demandOption: true,
+			describe: "Hathora developer token (required if no config file is present)",
+		},
+
 	},
 	handler: async (args) => {
 		const client = getProcessesApiClient(args.token);

--- a/src/commands/room/connect.ts
+++ b/src/commands/room/connect.ts
@@ -20,7 +20,12 @@ export const roomConnectionInfoCommand: CommandModule<
 			demandOption: true,
 			describe: "Id of the room",
 		},
-		token: { type: "string", demandOption: true, hidden: false },
+		token: {
+			type: "string",
+			demandOption: true,
+			describe: "Hathora developer token (required if no config file is present)",
+		},
+
 	},
 	handler: async (args) => {
 		const client = getRoomApiClient(args.token);

--- a/src/commands/room/connect.ts
+++ b/src/commands/room/connect.ts
@@ -23,7 +23,7 @@ export const roomConnectionInfoCommand: CommandModule<
 		token: {
 			type: "string",
 			demandOption: true,
-			describe: "Hathora developer token (required if no config file is present)",
+			describe: "Hathora developer token (required if not present in the config file)",
 		},
 
 	},

--- a/src/commands/room/connect.ts
+++ b/src/commands/room/connect.ts
@@ -20,7 +20,7 @@ export const roomConnectionInfoCommand: CommandModule<
 			demandOption: true,
 			describe: "Id of the room",
 		},
-		token: { type: "string", demandOption: true, hidden: true },
+		token: { type: "string", demandOption: true, hidden: false },
 	},
 	handler: async (args) => {
 		const client = getRoomApiClient(args.token);

--- a/src/commands/room/connect.ts
+++ b/src/commands/room/connect.ts
@@ -23,7 +23,7 @@ export const roomConnectionInfoCommand: CommandModule<
 		token: {
 			type: "string",
 			demandOption: true,
-			describe: "Hathora developer token (required if not present in the config file)",
+			describe: "Hathora developer token (required only for CI environments)",
 		},
 
 	},

--- a/src/commands/room/create.ts
+++ b/src/commands/room/create.ts
@@ -24,7 +24,7 @@ export const roomCreateCommand: CommandModule<
 		token: {
 			type: "string",
 			demandOption: true,
-			describe: "Hathora developer token (required if not present in the config file)",
+			describe: "Hathora developer token (required only for CI environments)",
 		},
 
 	},

--- a/src/commands/room/create.ts
+++ b/src/commands/room/create.ts
@@ -24,7 +24,7 @@ export const roomCreateCommand: CommandModule<
 		token: {
 			type: "string",
 			demandOption: true,
-			describe: "Hathora developer token (required if no config file is present)",
+			describe: "Hathora developer token (required if not present in the config file)",
 		},
 
 	},

--- a/src/commands/room/create.ts
+++ b/src/commands/room/create.ts
@@ -21,7 +21,7 @@ export const roomCreateCommand: CommandModule<
 			describe: "Region to create the room in",
 			choices: Object.values(Region),
 		},
-		token: { type: "string", demandOption: true, hidden: true },
+		token: { type: "string", demandOption: true, hidden: false },
 	},
 	handler: async (args) => {
 		const client = getRoomApiClient(args.token);

--- a/src/commands/room/create.ts
+++ b/src/commands/room/create.ts
@@ -21,7 +21,12 @@ export const roomCreateCommand: CommandModule<
 			describe: "Region to create the room in",
 			choices: Object.values(Region),
 		},
-		token: { type: "string", demandOption: true, hidden: false },
+		token: {
+			type: "string",
+			demandOption: true,
+			describe: "Hathora developer token (required if no config file is present)",
+		},
+
 	},
 	handler: async (args) => {
 		const client = getRoomApiClient(args.token);


### PR DESCRIPTION
Two minor changes:
1. Stop hiding `token` argument in the help message of a command
2. Expand wrap to be the current terminal width instead of the fixed 80 characters

## Before
```bash
% hathora-cloud deploy --help
hathora-cloud deploy

create a deployment for an app

Options:
  --version          Show version number                               [boolean]
  --help             Show help                                         [boolean]
  --appId            Id of the app                           [string] [required]
  --file             path to the tgz archive to deploy                  [string]
  --roomsPerProcess  number of rooms per process                        [number]
  --planName         plan name
                          [string] [choices: "tiny", "small", "medium", "large"]
  --transportType    transport type      [string] [choices: "tcp", "udp", "tls"]
  --containerPort    port the container listens to                      [number]
  --env              JSON stringified version of env variables array (name and v
                     alue)                                              [string]
```

## After
```bash
% node ./dist/cli.js deploy --help
hathora-cloud deploy

create a deployment for an app

Options:
  --version          Show version number                                                                                    [boolean]
  --help             Show help                                                                                              [boolean]
  --appId            Id of the app                                                                                [string] [required]
  --file             path to the tgz archive to deploy                                                                       [string]
  --roomsPerProcess  number of rooms per process                                                                             [number]
  --planName         plan name                                                 [string] [choices: "tiny", "small", "medium", "large"]
  --transportType    transport type                                                           [string] [choices: "tcp", "udp", "tls"]
  --containerPort    port the container listens to                                                                           [number]
  --env              JSON stringified version of env variables array (name and value)                                        [string]
  --token            Hathora developer token (required if not present in the config file)                         [string] [required]
```