### PR TITLE
Fix initial deploy

### DIFF
--- a/src/commands/deployments/create.ts
+++ b/src/commands/deployments/create.ts
@@ -17,19 +17,18 @@ export const createDeployment = async (
 ): Promise<Deployment> => {
 	const client = getDeploymentApiClient(args.token);
 	try {
-		const lastDeployment = await client.getLatestDeploymentDeprecated({
-			appId: args.appId,
-		});
-
+		let lastDeployment: Deployment | undefined;
 		if (
-			lastDeployment === undefined &&
-			(args.buildId === undefined ||
-				args.roomsPerProcess === undefined ||
-				args.planName === undefined ||
-				args.transportType === undefined ||
-				args.containerPort === undefined)
+			args.buildId === undefined ||
+			args.roomsPerProcess === undefined ||
+			args.planName === undefined ||
+			args.transportType === undefined ||
+			args.containerPort === undefined
 		) {
-			throw new Error("All args must be present for the initial deployment");
+			console.log("Some args missing, copying values from the last deployment");
+			lastDeployment = await client.getLatestDeploymentDeprecated({
+				appId: args.appId,
+			});
 		}
 
 		const deployment = await client.createDeploymentDeprecated({

--- a/src/commands/deployments/create.ts
+++ b/src/commands/deployments/create.ts
@@ -26,9 +26,13 @@ export const createDeployment = async (
 			args.containerPort === undefined
 		) {
 			console.log("Some args missing, copying values from the last deployment");
-			lastDeployment = await client.getLatestDeploymentDeprecated({
-				appId: args.appId,
-			});
+			try {
+				lastDeployment = await client.getLatestDeploymentDeprecated({
+					appId: args.appId,
+				});
+			} catch (e) {
+				throw new Error("No previous deployment found");
+			}
 		}
 
 		const deployment = await client.createDeploymentDeprecated({


### PR DESCRIPTION
This bug was preventing initial deployment to be done through the CLI, since `client.getLatestDeployment` would return a 404